### PR TITLE
fix typo in jupyter-kernelspec command

### DIFF
--- a/_downloads/side_by_side.html
+++ b/_downloads/side_by_side.html
@@ -77,7 +77,7 @@ the start of the line.
 Code chunks can accept up to two positional arguments
 
 - `kernel_name` (required)
-  See `jupyter-kernelspect list` for a list of the kernels installed on your
+  See `jupyter-kernelspec list` for a list of the kernels installed on your
   system
 - `chunk_name` (optional)
   And identifier for the code chunk. Used in several places for
@@ -111,7 +111,7 @@ The rest of this document is intended to demonstrate `stitch` in action.
 
 
 <ul>
-<li><code>kernel_name</code> (required) See <code>jupyter-kernelspect list</code> for a list of the kernels installed on your system</li>
+<li><code>kernel_name</code> (required) See <code>jupyter-kernelspec list</code> for a list of the kernels installed on your system</li>
 <li><code>chunk_name</code> (optional) And identifier for the code chunk. Used in several places for naming figures and files</li>
 </ul>
 


### PR DESCRIPTION
I have a sinking suspicion this is not the furthest upstream place to make this correction, but can't find anything better, so I'm rolling with it.